### PR TITLE
Add update and delete handlers for standards

### DIFF
--- a/app/api/settings/standards/route.ts
+++ b/app/api/settings/standards/route.ts
@@ -46,3 +46,62 @@ export async function POST(request: Request) {
         return NextResponse.json({ message: 'Failed to create standard', error: error instanceof Error ? error.message : String(error) }, { status: 500 });
     }
 }
+
+// PUT update a standard by id
+export async function PUT(request: Request) {
+    try {
+        const url = new URL(request.url);
+        const id = url.searchParams.get('id');
+        const data = await request.json();
+
+        if (!id || !ObjectId.isValid(id)) {
+            return NextResponse.json({ message: 'Invalid or missing id' }, { status: 400 });
+        }
+
+        const { db } = await connectToDatabase();
+        const updateData = {
+            ...data,
+            updatedAt: new Date(),
+        };
+        delete (updateData as any)._id;
+
+        const result = await db.collection(STANDARDS_COLLECTION).updateOne(
+            { _id: new ObjectId(id) },
+            { $set: updateData }
+        );
+
+        if (result.matchedCount === 0) {
+            return NextResponse.json({ message: 'Standard not found' }, { status: 404 });
+        }
+
+        const updatedStandard = await db.collection(STANDARDS_COLLECTION).findOne({ _id: new ObjectId(id) });
+        return NextResponse.json(updatedStandard, { status: 200 });
+    } catch (error) {
+        console.error('Failed to update standard:', error);
+        return NextResponse.json({ message: 'Failed to update standard', error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+    }
+}
+
+// DELETE a standard by id
+export async function DELETE(request: Request) {
+    try {
+        const url = new URL(request.url);
+        const id = url.searchParams.get('id');
+
+        if (!id || !ObjectId.isValid(id)) {
+            return NextResponse.json({ message: 'Invalid or missing id' }, { status: 400 });
+        }
+
+        const { db } = await connectToDatabase();
+        const result = await db.collection(STANDARDS_COLLECTION).deleteOne({ _id: new ObjectId(id) });
+
+        if (result.deletedCount === 0) {
+            return NextResponse.json({ message: 'Standard not found' }, { status: 404 });
+        }
+
+        return NextResponse.json({ message: 'Standard deleted successfully' }, { status: 200 });
+    } catch (error) {
+        console.error('Failed to delete standard:', error);
+        return NextResponse.json({ message: 'Failed to delete standard', error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+    }
+}


### PR DESCRIPTION
## Summary
- enable updating and deleting ISO standards

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468644693c8321b1441f3e0dfe6317