### PR TITLE
Move audit completion button

### DIFF
--- a/app/(dashboard)/audit/[id]/page.tsx
+++ b/app/(dashboard)/audit/[id]/page.tsx
@@ -75,7 +75,10 @@ export default function AuditDetailPage() {
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                         <div className="space-y-1"><p className="text-sm font-medium text-muted-foreground">Nama Audit</p><p>{audit.name}</p></div>
                         <div className="space-y-1"><p className="text-sm font-medium text-muted-foreground">Standar</p><p>{audit.standard}</p></div>
-                        <div className="space-y-1"><p className="text-sm font-medium text-muted-foreground">Jenis Audit</p><p><Badge variant={audit.auditType === 'Internal' ? 'default' : 'secondary'}>{audit.auditType}</Badge></p></div>
+                        <div className="space-y-1">
+                            <p className="text-sm font-medium text-muted-foreground">Jenis Audit</p>
+                            <Badge variant={audit.auditType === 'Internal' ? 'default' : 'secondary'}>{audit.auditType}</Badge>
+                        </div>
                         <div className="space-y-1"><p className="text-sm font-medium text-muted-foreground">Tanggal & Waktu</p><p className="flex items-center"><Calendar className="mr-2 h-4 w-4" />{new Date(audit.date).toLocaleDateString()} {audit.scheduledTime && `pukul ${audit.scheduledTime}`}</p></div>
                         <div className="space-y-1"><p className="text-sm font-medium text-muted-foreground">Status</p><p>{audit.status}</p></div>
                         <div className="space-y-1"><p className="text-sm font-medium text-muted-foreground">{audit.auditType === 'Internal' ? 'Departemen' : 'Lembaga'}</p><p className="flex items-center"><Building className="mr-2 h-4 w-4" />{audit.auditType === 'Internal' ? audit.department : audit.auditor}</p></div>

--- a/app/(dashboard)/audit/findings/[id]/page.tsx
+++ b/app/(dashboard)/audit/findings/[id]/page.tsx
@@ -11,6 +11,7 @@ import { useToast } from "@/components/ui/use-toast";
 // Definisikan tipe data di sini
 interface Finding {
     _id: string;
+    auditId: string;
     auditName: string;
     findingType: string;
     severity: string;
@@ -26,10 +27,27 @@ interface Finding {
 
 export default function FindingDetailPage() {
     const params = useParams();
+    const router = useRouter();
     const { toast } = useToast();
     const findingId = params.id as string;
     const [finding, setFinding] = useState<Finding | null>(null);
     const [isLoading, setIsLoading] = useState(true);
+
+    const handleCompleteAudit = async () => {
+        if (!finding) return;
+        try {
+            const res = await fetch(`/api/audits/${finding.auditId}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ status: 'Completed' })
+            });
+            if (!res.ok) throw new Error('Gagal menyelesaikan audit.');
+            toast({ title: 'Audit Diselesaikan', description: 'Status audit diperbarui.' });
+            router.push('/audit');
+        } catch (error) {
+            toast({ variant: 'destructive', title: 'Error', description: (error as Error).message });
+        }
+    };
 
     useEffect(() => {
         if (!findingId) return;
@@ -57,7 +75,10 @@ export default function FindingDetailPage() {
                     <Link href="/audit"><Button variant="outline" size="icon"><ArrowLeft className="h-4 w-4" /></Button></Link>
                     <div><h1 className="text-3xl font-bold">Detail Temuan</h1><p className="text-muted-foreground">{finding.description.substring(0, 50)}...</p></div>
                 </div>
-                <Link href={`/audit/findings/${finding._id}/edit`}><Button><Edit className="mr-2 h-4 w-4" /> Edit</Button></Link>
+                <div className="flex space-x-2">
+                    <Link href={`/audit/findings/${finding._id}/edit`}><Button><Edit className="mr-2 h-4 w-4" /> Edit</Button></Link>
+                    <Button variant="outline" onClick={handleCompleteAudit}>Selesaikan Audit</Button>
+                </div>
             </div>
             <Card>
                 <CardHeader><CardTitle>{finding.findingType}: {finding.auditName}</CardTitle></CardHeader>
@@ -67,7 +88,7 @@ export default function FindingDetailPage() {
                     <p><strong>Rekomendasi:</strong> {finding.recommendation}</p>
                     <div className="grid grid-cols-2 gap-4 pt-4 border-t">
                         <p><strong>Tingkat:</strong> {finding.severity}</p>
-                        <p><strong>Klausul:</strong> {finding.clause}</p> {/* <-- TAMBAHKAN BARIS INI */}
+                        <p><strong>Klausul:</strong> {finding.clause}</p>
                         <p><strong>Departemen:</strong> {finding.department}</p>
                         <p><strong>Penanggung Jawab:</strong> {finding.responsiblePerson}</p>
                         <p><strong>Status:</strong> {finding.status}</p>

--- a/app/api/settings/standards/route.ts
+++ b/app/api/settings/standards/route.ts
@@ -4,7 +4,6 @@ import { connectToDatabase } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 
 
-// --- TAMBAHKAN BARIS INI UNTUK MENONAKTIFKAN CACHING ---
 export const dynamic = 'force-dynamic';
 const STANDARDS_COLLECTION = 'iso_standards';
 

--- a/components/audit/add-finding-modal.tsx
+++ b/components/audit/add-finding-modal.tsx
@@ -32,7 +32,7 @@ interface DepartmentOption {
 }
 
 interface AddFindingModalProps {
-  onAddFinding: () => void;
+  onAddFinding: (auditId: string) => void;
   audits: AuditOption[];
 }
 
@@ -98,10 +98,10 @@ export function AddFindingModal({ onAddFinding, audits }: AddFindingModalProps) 
       });
       if (!response.ok) throw new Error((await response.json()).message || 'Gagal menyimpan temuan.');
 
-      toast({ title: "Sukses", description: "Temuan baru berhasil ditambahkan." });
-      onAddFinding();
-      setFormData(initialFormState);
-      setOpen(false);
+    toast({ title: "Sukses", description: "Temuan baru berhasil ditambahkan." });
+    onAddFinding(formData.auditId);
+    setFormData(initialFormState);
+    setOpen(false);
     } catch (error) {
       toast({ variant: "destructive", title: "Error", description: (error as Error).message });
     } finally {
@@ -135,7 +135,6 @@ export function AddFindingModal({ onAddFinding, audits }: AddFindingModalProps) 
 
             <div className="space-y-2"><Label htmlFor="description">Deskripsi Temuan *</Label><Textarea id="description" value={formData.description} onChange={e => handleInputChange("description", e.target.value)} required rows={3} placeholder="Jelaskan temuan secara detail..."/></div>
 
-            {/* --- FIELD YANG DIKEMBALIKAN --- */}
             <div className="space-y-2"><Label htmlFor="evidence">Bukti/Evidence</Label><Textarea id="evidence" value={formData.evidence} onChange={e => handleInputChange("evidence", e.target.value)} rows={3} placeholder="Jelaskan bukti yang mendukung temuan..."/></div>
             <div className="space-y-2"><Label htmlFor="recommendation">Rekomendasi</Label><Textarea id="recommendation" value={formData.recommendation} onChange={e => handleInputChange("recommendation", e.target.value)} rows={3} placeholder="Berikan rekomendasi perbaikan..."/></div>
 

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -24,12 +24,12 @@ const badgeVariants = cva(
 )
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
+  extends React.HTMLAttributes<HTMLSpanElement>,
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+    <span className={cn(badgeVariants({ variant }), className)} {...props} />
   )
 }
 


### PR DESCRIPTION
## Summary
- show "Selesaikan Audit" button in finding results tab
- allow AddFindingModal to return the updated audit ID
- render `Badge` as `span` to avoid invalid DOM nesting

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68772264ee0c8321afd990b08349bd9d