### PR TITLE
Fix audit completion workflow

### DIFF
--- a/app/(dashboard)/audit/[id]/finish/page.tsx
+++ b/app/(dashboard)/audit/[id]/finish/page.tsx
@@ -1,0 +1,271 @@
+"use client"
+
+import { useState, useEffect, FormEvent } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+import { ArrowLeft, Save, Upload, X } from "lucide-react";
+
+interface Audit {
+  _id: string;
+  name: string;
+  standard: string;
+  department: string;
+  auditor: string;
+  date: string;
+  scope?: string;
+  objectives?: string;
+  criteria?: string;
+  completedDate?: string;
+  duration?: string;
+  findings?: number;
+  conclusion?: string;
+  reportFile?: string;
+  evidenceFiles?: string[];
+}
+
+export default function FinishAuditPage() {
+  const params = useParams();
+  const router = useRouter();
+  const { toast } = useToast();
+  const auditId = params.id as string;
+
+  const [audit, setAudit] = useState<Audit | null>(null);
+  const [formData, setFormData] = useState<Partial<Audit>>({});
+  const [reportFile, setReportFile] = useState<File | null>(null);
+  const [evidenceFiles, setEvidenceFiles] = useState<File[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!auditId) return;
+    const fetchAudit = async () => {
+      setIsLoading(true);
+      try {
+        const res = await fetch(`/api/audits/${auditId}`);
+        if (!res.ok) throw new Error("Gagal memuat data audit.");
+        const data: Audit = await res.json();
+        setAudit(data);
+        setFormData({
+          name: data.name,
+          standard: data.standard,
+          department: data.department,
+          auditor: data.auditor,
+          date: data.date,
+          scope: data.scope || "",
+          objectives: data.objectives || "",
+          criteria: data.criteria || "",
+          completedDate: new Date().toISOString().split("T")[0],
+          duration: data.duration || "",
+          findings: data.findings || 0,
+          conclusion: data.conclusion || "",
+        });
+      } catch (error) {
+        toast({ variant: "destructive", title: "Error", description: (error as Error).message });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchAudit();
+  }, [auditId, toast]);
+
+  const handleReportChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setReportFile(file);
+  };
+
+  const handleEvidenceChange = (files: FileList | null) => {
+    if (!files) return;
+    setEvidenceFiles(Array.from(files));
+  };
+
+  const removeEvidenceFile = (index: number) => {
+    setEvidenceFiles(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const handleInputChange = (field: keyof Audit, value: string | number) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!audit) return;
+    setIsSaving(true);
+    try {
+      let reportFileId = audit.reportFile || null;
+      if (reportFile) {
+        const data = new FormData();
+        data.append("file", reportFile);
+        const uploadRes = await fetch("/api/upload", { method: "POST", body: data });
+        if (!uploadRes.ok) throw new Error("Gagal mengupload laporan.");
+        const uploadResult = await uploadRes.json();
+        reportFileId = uploadResult.fileId;
+      }
+
+      let evidenceFileIds = audit.evidenceFiles ? [...audit.evidenceFiles] : [];
+      for (const file of evidenceFiles) {
+        const fd = new FormData();
+        fd.append("file", file);
+        const up = await fetch("/api/upload", { method: "POST", body: fd });
+        if (!up.ok) throw new Error("Gagal mengupload evidence.");
+        const upRes = await up.json();
+        evidenceFileIds.push(upRes.fileId);
+      }
+
+      const payload = {
+        ...audit,
+        ...formData,
+        status: "Completed",
+        reportFile: reportFileId,
+        evidenceFiles: evidenceFileIds,
+      };
+
+      const res = await fetch(`/api/audits/${audit._id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error("Gagal menyelesaikan audit.");
+      toast({ title: "Sukses", description: "Audit telah diselesaikan." });
+      router.push(`/audit/${audit._id}`);
+    } catch (error) {
+      toast({ variant: "destructive", title: "Error", description: (error as Error).message });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) return <div className="container p-6 text-center">Memuat form...</div>;
+  if (!audit) return <div className="container p-6 text-center text-red-500">Audit tidak ditemukan.</div>;
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <div className="flex items-center space-x-4 mb-6">
+        <Link href={`/audit/${audit._id}`}>
+          <Button variant="outline" size="icon">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <h1 className="text-3xl font-bold">Selesaikan Audit</h1>
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Informasi Dasar</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="name">Nama Audit *</Label>
+                <Input id="name" value={formData.name || ""} onChange={e => handleInputChange("name", e.target.value)} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="standard">Standar *</Label>
+                <Input id="standard" value={formData.standard || ""} onChange={e => handleInputChange("standard", e.target.value)} required />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="department">Departemen *</Label>
+                <Input id="department" value={formData.department || ""} onChange={e => handleInputChange("department", e.target.value)} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="auditor">Auditor *</Label>
+                <Input id="auditor" value={formData.auditor || ""} onChange={e => handleInputChange("auditor", e.target.value)} required />
+              </div>
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="date">Tanggal Mulai *</Label>
+                <Input id="date" type="date" value={formData.date || ""} onChange={e => handleInputChange("date", e.target.value)} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="completedDate">Tanggal Selesai *</Label>
+                <Input id="completedDate" type="date" value={formData.completedDate || ""} onChange={e => handleInputChange("completedDate", e.target.value)} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="duration">Durasi</Label>
+                <Input id="duration" value={formData.duration || ""} onChange={e => handleInputChange("duration", e.target.value)} placeholder="Contoh: 2 hari" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Detail Audit</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="scope">Ruang Lingkup Audit</Label>
+              <Textarea id="scope" value={formData.scope || ""} onChange={e => handleInputChange("scope", e.target.value)} rows={2} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="objectives">Tujuan Audit</Label>
+              <Textarea id="objectives" value={formData.objectives || ""} onChange={e => handleInputChange("objectives", e.target.value)} rows={2} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="criteria">Kriteria Audit</Label>
+              <Textarea id="criteria" value={formData.criteria || ""} onChange={e => handleInputChange("criteria", e.target.value)} rows={2} />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Hasil Audit</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="findings">Jumlah Temuan</Label>
+                <Input id="findings" type="number" value={formData.findings ?? ""} onChange={e => handleInputChange("findings", parseInt(e.target.value || "0"))} min="0" />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="conclusion">Kesimpulan Audit</Label>
+              <Textarea id="conclusion" value={formData.conclusion || ""} onChange={e => handleInputChange("conclusion", e.target.value)} rows={3} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="reportFile">Upload Laporan Audit</Label>
+              <div className="flex items-center space-x-2">
+                <Input id="reportFile" type="file" accept=".pdf,.doc,.docx" onChange={handleReportChange} className="flex-1" />
+                <Upload className="h-4 w-4 text-muted-foreground" />
+              </div>
+              {reportFile && <p className="text-sm text-muted-foreground">{reportFile.name}</p>}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="evidenceFiles">Upload Bukti/Evidence (Multiple Files)</Label>
+              <div className="flex items-center space-x-2">
+                <Input id="evidenceFiles" type="file" multiple accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.xls,.xlsx" onChange={e => handleEvidenceChange(e.target.files)} className="flex-1" />
+                <Upload className="h-4 w-4 text-muted-foreground" />
+              </div>
+              {evidenceFiles.length > 0 && (
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">Files uploaded:</p>
+                  {evidenceFiles.map((file, index) => (
+                    <div key={index} className="flex items-center justify-between text-sm text-muted-foreground">
+                      <span>{file.name}</span>
+                      <Button type="button" variant="ghost" size="sm" onClick={() => removeEvidenceFile(index)}>
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={isSaving}>{isSaving ? "Menyimpan..." : <><Save className="mr-2 h-4 w-4" /> Simpan Audit</>}</Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/app/(dashboard)/audit/[id]/page.tsx
+++ b/app/(dashboard)/audit/[id]/page.tsx
@@ -25,7 +25,6 @@ export default function AuditDetailPage() {
     const [audit, setAudit] = useState<Audit | null>(null);
     const [findings, setFindings] = useState<Finding[]>([]);
     const [isLoading, setIsLoading] = useState(true);
-    const [isCompleting, setIsCompleting] = useState(false);
 
     const fetchAuditData = async () => {
         if (!auditId) return;
@@ -54,34 +53,6 @@ export default function AuditDetailPage() {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [auditId]);
 
-    const handleCompleteAudit = async () => {
-        if (!audit) return;
-
-        const openFindings = findings.filter(f => f.status === 'Open' || f.status === 'In Progress');
-        if (openFindings.length > 0) {
-            if (!confirm(`Audit ini masih memiliki ${openFindings.length} temuan yang terbuka. Anda yakin ingin menyelesaikannya?`)) {
-                return;
-            }
-        }
-
-        setIsCompleting(true);
-        try {
-            const response = await fetch(`/api/audits/${audit._id}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ status: 'Completed', completedDate: new Date().toISOString() }),
-            });
-            if (!response.ok) throw new Error("Gagal memperbarui status audit.");
-
-            toast({ title: "Sukses", description: "Status audit telah diubah menjadi Selesai." });
-            fetchAuditData();
-            router.push('/audit'); // Kembali ke halaman utama
-        } catch (error) {
-            toast({ variant: "destructive", title: "Error", description: (error as Error).message });
-        } finally {
-            setIsCompleting(false);
-        }
-    };
 
     if (isLoading) return <div className="container p-6 text-center">Memuat detail audit...</div>;
     if (!audit) return <div className="container p-6 text-center text-red-500">Audit tidak ditemukan.</div>;
@@ -94,12 +65,6 @@ export default function AuditDetailPage() {
                     <div><h1 className="text-3xl font-bold">{audit.name}</h1></div>
                 </div>
                 <div className="flex items-center space-x-2">
-                    {audit.status === 'Scheduled' && (
-                        <Button onClick={handleCompleteAudit} disabled={isCompleting}>
-                            <CheckCircle2 className="mr-2 h-4 w-4" />
-                            {isCompleting ? 'Menyelesaikan...' : 'Selesaikan Audit'}
-                        </Button>
-                    )}
                     <Link href={`/audit/${audit._id}/edit`}><Button variant="outline"><Edit className="mr-2 h-4 w-4" /> Edit</Button></Link>
                 </div>
             </div>
@@ -126,8 +91,21 @@ export default function AuditDetailPage() {
                 <TabsContent value="findings">
                     <Card>
                         <CardHeader className="flex flex-row items-center justify-between">
-                            <div><CardTitle>Daftar Temuan</CardTitle><CardDescription>Semua temuan yang tercatat untuk audit ini.</CardDescription></div>
-                            <AddFindingModal onAddFinding={fetchAuditData} audits={[audit]} />
+                            <div>
+                                <CardTitle>Daftar Temuan</CardTitle>
+                                <CardDescription>Semua temuan yang tercatat untuk audit ini.</CardDescription>
+                            </div>
+                            <div className="flex space-x-2">
+                                {audit.status === 'Scheduled' && (
+                                    <Link href={`/audit/${audit._id}/finish`}>
+                                        <Button>
+                                            <CheckCircle2 className="mr-2 h-4 w-4" />
+                                            Selesaikan Audit
+                                        </Button>
+                                    </Link>
+                                )}
+                                <AddFindingModal onAddFinding={fetchAuditData} audits={[audit]} />
+                            </div>
                         </CardHeader>
                         <CardContent>
                             <table className="w-full">

--- a/app/(dashboard)/audit/[id]/report/page.tsx
+++ b/app/(dashboard)/audit/[id]/report/page.tsx
@@ -1,137 +1,263 @@
 "use client"
 
-import { useState, useEffect } from 'react';
-import { useParams } from 'next/navigation';
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
-import { ArrowLeft, Download, FileText, Calendar, User, Building, CheckCircle2, AlertTriangle, XCircle, ListChecks } from "lucide-react";
-import Link from "next/link";
-import { useToast } from '@/components/ui/use-toast';
+import { useState, useEffect } from "react"
+import { useParams } from "next/navigation"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { useToast } from "@/components/ui/use-toast"
+import { ArrowLeft, Download, FileText, CheckCircle2, AlertTriangle } from "lucide-react"
 
-// Definisikan tipe data di sini
 interface Finding {
-  _id: string;
-  findingType: string;
-  severity: string;
-  clause: string;
-  description: string;
-  evidence: string;
-  recommendation: string;
-  status: string;
+  _id: string
+  type: string
+  severity: string
+  clause: string
+  description: string
+  evidence: string
+  recommendation: string
+  status: string
 }
 
-interface AuditReportData {
-  _id: string;
-  name: string;
-  standard: string;
-  department: string;
-  auditDate: string;
-  completedDate: string;
-  auditTeam: string[];
-  scope: string;
-  objective: string;
-  summary: string;
-  positiveFindings: string[];
-  recommendations: string[];
-  nextAuditDate: string;
-  findings: Finding[];
+interface AuditReport {
+  _id: string
+  name: string
+  standard: string
+  department: string
+  auditDate: string
+  completedDate: string
+  auditTeam: string[]
+  scope: string
+  objective: string
+  summary: string
+  positiveFindings: string[]
+  recommendations: string[]
+  findings: Finding[]
 }
-
 
 export default function AuditReportPage() {
-  const params = useParams();
-  const { toast } = useToast();
-  const auditId = params.id as string;
-  const [report, setReport] = useState<AuditReportData | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const params = useParams()
+  const { toast } = useToast()
+  const auditId = params.id as string
+
+  const [auditReport, setAuditReport] = useState<AuditReport | null>(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    if (!auditId) return;
-
-    const fetchReportData = async () => {
-      setIsLoading(true);
+    if (!auditId) return
+    const fetchData = async () => {
+      setLoading(true)
       try {
-        // Ambil detail audit dan semua finding yang terkait
         const [auditRes, findingsRes] = await Promise.all([
           fetch(`/api/audits/${auditId}`),
-          fetch(`/api/findings?auditId=${auditId}`) // API findings perlu mendukung filter ini
-        ]);
-
-        if (!auditRes.ok || !findingsRes.ok) throw new Error("Gagal memuat data laporan audit.");
-
-        const auditData = await auditRes.json();
-        const findingsData = await findingsRes.json();
-
-        // Gabungkan data menjadi satu objek report
-        setReport({
-          ...auditData,
-          auditDate: auditData.date, // Ganti nama field jika perlu
-          auditTeam: [auditData.auditor], // Asumsi auditor adalah tim
-          summary: "Audit dilaksanakan selama 2 hari...", // Data statis untuk contoh
-          positiveFindings: ["Sistem dokumentasi baik.", "Komitmen manajemen tinggi."], // Data statis
-          recommendations: ["Perbaiki sistem kalibrasi.", "Lengkapi training record."], // Data statis
-          nextAuditDate: "2025-05-15", // Data statis
+          fetch(`/api/findings?auditId=${auditId}`)
+        ])
+        if (!auditRes.ok || !findingsRes.ok) throw new Error("Gagal memuat data laporan audit.")
+        const auditData = await auditRes.json()
+        const findingsData = await findingsRes.json()
+        setAuditReport({
+          _id: auditData._id,
+          name: auditData.name,
+          standard: auditData.standard,
+          department: auditData.department,
+          auditDate: auditData.date,
+          completedDate: auditData.completedDate || "",
+          auditTeam: [auditData.auditor],
+          scope: auditData.scope || "",
+          objective: auditData.objectives || "",
+          summary: auditData.conclusion || "",
+          positiveFindings: auditData.positiveFindings || [],
+          recommendations: auditData.recommendations || [],
           findings: findingsData,
-        });
-
+        })
       } catch (error) {
-        toast({ variant: "destructive", title: "Error", description: (error as Error).message });
+        toast({ variant: "destructive", title: "Error", description: (error as Error).message })
       } finally {
-        setIsLoading(false);
+        setLoading(false)
       }
-    };
+    }
+    fetchData()
+  }, [auditId, toast])
 
-    fetchReportData();
-  }, [auditId, toast]);
+  const getSeverityColor = (severity: string) => {
+    if (severity === "Critical") return "bg-red-600 text-white"
+    if (severity === "Major") return "bg-orange-500 text-white"
+    if (severity === "Minor") return "bg-yellow-400 text-black"
+    return "bg-gray-400 text-white"
+  }
 
-  const getSeverityColor = (severity: string) => { /* ... (fungsi sama seperti sebelumnya) */ };
-  const getStatusColor = (status: string) => { /* ... (fungsi sama seperti sebelumnya) */ };
+  const getStatusColor = (status: string) => {
+    if (status === "Open") return "bg-red-100 text-red-800"
+    if (status === "In Progress") return "bg-yellow-100 text-yellow-800"
+    if (status === "Closed") return "bg-green-100 text-green-800"
+    return "bg-gray-100 text-gray-800"
+  }
 
-  if (isLoading) return <div className="container p-6 text-center">Memuat laporan...</div>;
-  if (!report) return <div className="container p-6 text-center text-red-500">Laporan tidak ditemukan.</div>;
+  const getStatusIcon = (status: string) => {
+    if (status === "Closed") return <CheckCircle2 className="h-3 w-3" />
+    if (status === "Open") return <AlertTriangle className="h-3 w-3" />
+    return <AlertTriangle className="h-3 w-3" />
+  }
+
+  if (loading) return <div className="container p-6 text-center">Memuat laporan...</div>
+  if (!auditReport) return <div className="container p-6 text-center text-red-500">Laporan tidak ditemukan.</div>
 
   return (
-      <div className="container mx-auto px-4 py-6 bg-gray-50 dark:bg-gray-900">
-        <div className="flex items-center justify-between mb-6">
-          <div className="flex items-center space-x-4">
-            <Link href="/audit"><Button variant="outline" size="sm"><ArrowLeft className="mr-2 h-4 w-4" />Kembali</Button></Link>
-            <div><h1 className="text-3xl font-bold">Laporan Audit</h1><p className="text-muted-foreground">{report.name}</p></div>
+    <div className="container mx-auto px-4 py-6">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center space-x-4">
+          <Link href="/audit">
+            <Button variant="outline" size="sm">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Kembali ke Audit
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-3xl font-bold">Laporan Audit</h1>
+            <p className="text-muted-foreground">{auditReport.name}</p>
           </div>
-          <div><Button variant="outline"><Download className="mr-2 h-4 w-4" />Export PDF</Button></div>
         </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 space-y-6">
-            {/* ... (Kartu Informasi Audit, Ringkasan Eksekutif, dll) ... */}
-            <Card><CardHeader><CardTitle>Temuan Audit</CardTitle><CardDescription>Detail temuan dan rekomendasi perbaikan</CardDescription></CardHeader>
-              <CardContent className="space-y-6">
-                {report.findings.map((finding, index) => (
-                    <div key={finding._id} className="border rounded-lg p-4">
-                      <div className="flex items-start justify-between mb-3">
-                        <div className="flex items-center space-x-2 flex-wrap">
-                          <span className="font-semibold">Temuan #{index + 1}</span>
-                          <Badge variant="outline">{finding.findingType}</Badge>
-                          <Badge variant="destructive">{finding.severity}</Badge>
-                          <Badge variant="secondary">Klausul {finding.clause}</Badge>
-                        </div>
-                        <Badge className={getStatusColor(finding.status)}>{finding.status}</Badge>
-                      </div>
-                      <div className="space-y-3 mt-2">
-                        <div><label className="text-sm font-medium text-muted-foreground">Deskripsi</label><p className="text-sm mt-1">{finding.description}</p></div>
-                        <div><label className="text-sm font-medium text-muted-foreground">Bukti</label><p className="text-sm mt-1">{finding.evidence}</p></div>
-                        <div><label className="text-sm font-medium text-muted-foreground">Rekomendasi</label><p className="text-sm mt-1">{finding.recommendation}</p></div>
-                      </div>
-                    </div>
-                ))}
-              </CardContent>
-            </Card>
-            <Card><CardHeader><CardTitle>Temuan Positif</CardTitle></CardHeader><CardContent><ul className="list-disc pl-5 space-y-2">{report.positiveFindings.map((item, i) => <li key={i}>{item}</li>)}</ul></CardContent></Card>
-            <Card><CardHeader><CardTitle>Rekomendasi Umum</CardTitle></CardHeader><CardContent><ul className="list-disc pl-5 space-y-2">{report.recommendations.map((item, i) => <li key={i}>{item}</li>)}</ul></CardContent></Card>
-          </div>
-          <div className="space-y-6">{/* ... (Sidebar: Ringkasan, Aksi Cepat) ... */}</div>
+        <div className="flex space-x-2">
+          <Button variant="outline">
+            <Download className="mr-2 h-4 w-4" />
+            Export PDF
+          </Button>
+          <Button variant="outline">
+            <FileText className="mr-2 h-4 w-4" />
+            Print
+          </Button>
         </div>
       </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Informasi Audit</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="text-sm font-medium text-muted-foreground">Standar</label>
+                  <p className="font-medium">{auditReport.standard}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-muted-foreground">Departemen</label>
+                  <p className="font-medium">{auditReport.department}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-muted-foreground">Tanggal Audit</label>
+                  <p className="font-medium">{auditReport.auditDate}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-muted-foreground">Tanggal Selesai</label>
+                  <p className="font-medium">{auditReport.completedDate}</p>
+                </div>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">Tim Auditor</label>
+                <p className="font-medium">{auditReport.auditTeam.join(", ")}</p>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">Ruang Lingkup</label>
+                <p className="font-medium">{auditReport.scope}</p>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">Tujuan</label>
+                <p className="font-medium">{auditReport.objective}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Ringkasan Eksekutif</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground leading-relaxed">{auditReport.summary}</p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Temuan Audit</CardTitle>
+              <CardDescription>Detail temuan dan rekomendasi perbaikan</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {auditReport.findings.map((finding, index) => (
+                <div key={finding._id} className="border rounded-lg p-4">
+                  <div className="flex items-start justify-between mb-3">
+                    <div className="flex items-center space-x-2">
+                      <span className="font-semibold">Temuan #{index + 1}</span>
+                      <Badge variant="outline">{finding.type}</Badge>
+                      <div className="flex items-center space-x-1">
+                        <div className={`w-3 h-3 rounded-full ${getSeverityColor(finding.severity)}`}></div>
+                        <span className="text-sm">{finding.severity}</span>
+                      </div>
+                      <Badge variant="outline">Klausul {finding.clause}</Badge>
+                    </div>
+                    <Badge className={getStatusColor(finding.status)}>
+                      {getStatusIcon(finding.status)}
+                      <span className="ml-1">{finding.status}</span>
+                    </Badge>
+                  </div>
+
+                  <div className="space-y-3">
+                    <div>
+                      <label className="text-sm font-medium text-muted-foreground">Deskripsi</label>
+                      <p className="text-sm mt-1">{finding.description}</p>
+                    </div>
+                    <div>
+                      <label className="text-sm font-medium text-muted-foreground">Bukti</label>
+                      <p className="text-sm mt-1">{finding.evidence}</p>
+                    </div>
+                    <div>
+                      <label className="text-sm font-medium text-muted-foreground">Rekomendasi</label>
+                      <p className="text-sm mt-1">{finding.recommendation}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Temuan Positif</CardTitle>
+              <CardDescription>Aspek yang sudah berjalan dengan baik</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-2">
+                {auditReport.positiveFindings.map((finding, index) => (
+                  <li key={index} className="flex items-start space-x-2">
+                    <CheckCircle2 className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                    <span className="text-sm">{finding}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Rekomendasi Umum</CardTitle>
+              <CardDescription>Saran perbaikan untuk sistem manajemen</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-2">
+                {auditReport.recommendations.map((rec, index) => (
+                  <li key={index} className="flex items-start space-x-2">
+                    <AlertTriangle className="h-5 w-5 text-amber-500 mt-0.5 flex-shrink-0" />
+                    <span className="text-sm">{rec}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+        <div className="space-y-6"></div>
+      </div>
+    </div>
   )
 }

--- a/app/(dashboard)/audit/findings/[id]/page.tsx
+++ b/app/(dashboard)/audit/findings/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ArrowLeft, Edit } from "lucide-react";

--- a/app/(dashboard)/audit/page.tsx
+++ b/app/(dashboard)/audit/page.tsx
@@ -136,19 +136,36 @@ export default function AuditPage() {
     const AuditTable = ({ auditList }: { auditList: Audit[] }) => (
         <div className="overflow-x-auto">
             <table className="w-full">
-                <thead><tr className="border-b"><th className="p-4 text-left font-medium">Nama Audit</th><th className="p-4 text-left font-medium">Jenis</th><th className="p-4 text-left font-medium">Status</th><th className="p-4 text-left font-medium">Aksi</th></tr></thead>
+                <thead>
+                    <tr className="border-b">
+                        <th className="p-4 text-left font-medium">Nama Audit</th>
+                        <th className="p-4 text-left font-medium">Standar</th>
+                        <th className="p-4 text-left font-medium">Departemen</th>
+                        <th className="p-4 text-left font-medium">Jenis Audit</th>
+                        <th className="p-4 text-left font-medium">Tanggal</th>
+                        <th className="p-4 text-left font-medium">Status</th>
+                        <th className="p-4 text-left font-medium">Temuan</th>
+                        <th className="p-4 text-left font-medium">Aksi</th>
+                    </tr>
+                </thead>
                 <tbody>
                 {auditList.length > 0 ? auditList.map((audit) => (
                     <tr key={audit._id} className="border-b hover:bg-muted/50">
                         <td className="p-4 flex items-center"><FileCheck className="mr-2 h-4 w-4 text-blue-500" />{audit.name}</td>
+                        <td className="p-4">{audit.standard}</td>
+                        <td className="p-4">{audit.department}</td>
                         <td className="p-4"><Badge variant={audit.auditType === 'Internal' ? 'default' : 'secondary'}>{audit.auditType}</Badge></td>
+                        <td className="p-4">{new Date(audit.date).toLocaleDateString()}</td>
                         <td className="p-4"><div className="flex items-center">{getStatusIcon(audit.status)}<span className="ml-2">{getStatusText(audit.status)}</span></div></td>
+                        <td className="p-4 text-center">{audit.findings}</td>
                         <td className="p-4"><div className="flex space-x-1">
                             <Link href={`/audit/${audit._id}`}><Button title="Lihat" variant="ghost" size="icon"><Eye className="h-4 w-4" /></Button></Link>
                             <Link href={`/audit/${audit._id}/edit`}><Button title="Edit" variant="ghost" size="icon"><Edit className="h-4 w-4" /></Button></Link>
                         </div></td>
                     </tr>
-                )) : (<tr><td colSpan={4} className="p-4 text-center text-muted-foreground">Tidak ada data.</td></tr>)}
+                )) : (
+                    <tr><td colSpan={8} className="p-4 text-center text-muted-foreground">Tidak ada data.</td></tr>
+                )}
                 </tbody>
             </table>
         </div>
@@ -176,7 +193,78 @@ export default function AuditPage() {
                 <TabsContent value="internal"><Card><CardHeader><CardTitle>Audit Internal</CardTitle></CardHeader><CardContent>{isLoading ? <p className="text-center p-4">Memuat...</p> : <AuditTable auditList={audits.filter(a => a.auditType === 'Internal')} />}</CardContent></Card></TabsContent>
                 <TabsContent value="external"><Card><CardHeader><CardTitle>Audit Eksternal</CardTitle></CardHeader><CardContent>{isLoading ? <p className="text-center p-4">Memuat...</p> : <AuditTable auditList={audits.filter(a => a.auditType === 'External')} />}</CardContent></Card></TabsContent>
                 <TabsContent value="scheduled"><Card><CardHeader><CardTitle>Audit Dijadwalkan</CardTitle></CardHeader><CardContent>{isLoading ? <p className="text-center p-4">Memuat...</p> : <AuditTable auditList={audits.filter(a => isScheduledStatus(a.status))} />}</CardContent></Card></TabsContent>
-                <TabsContent value="completed"><Card><CardHeader><CardTitle>Audit Selesai</CardTitle></CardHeader><CardContent>{isLoading ? <p className="text-center p-4">Memuat...</p> : <AuditTable auditList={audits.filter(a => isCompletedStatus(a.status))} />}</CardContent></Card></TabsContent>
+                <TabsContent value="completed">
+                    <Card>
+                        <CardHeader className="pb-2 flex flex-row items-center justify-between">
+                            <div>
+                                <CardTitle>Audit Selesai</CardTitle>
+                                <CardDescription>Daftar audit yang telah selesai dilaksanakan</CardDescription>
+                            </div>
+                            <AddAuditModal onAddAudit={handleDataAdded} type="completed" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="overflow-x-auto">
+                                <table className="w-full">
+                                    <thead>
+                                        <tr className="border-b">
+                                            <th className="text-left py-3 px-4">Nama Audit</th>
+                                            <th className="text-left py-3 px-4">Standar</th>
+                                            <th className="text-left py-3 px-4">Auditor</th>
+                                            <th className="text-left py-3 px-4">Tanggal Selesai</th>
+                                            <th className="text-left py-3 px-4">Temuan</th>
+                                            <th className="text-left py-3 px-4">Files</th>
+                                            <th className="text-left py-3 px-4">Laporan</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {audits.filter(a => isCompletedStatus(a.status)).map(audit => (
+                                            <tr key={audit._id} className="border-b hover:bg-muted/50">
+                                                <td className="py-3 px-4 flex items-center">
+                                                    <CheckCircle2 className="mr-2 h-4 w-4 text-green-500" />
+                                                    {audit.name}
+                                                </td>
+                                                <td className="py-3 px-4">{audit.standard}</td>
+                                                <td className="py-3 px-4">{audit.auditor}</td>
+                                                <td className="py-3 px-4">{audit.completedDate ? audit.completedDate : '-'}</td>
+                                                <td className="py-3 px-4">
+                                                    {audit.findings && audit.findings > 0 ? (
+                                                        <Badge variant="destructive">{audit.findings} temuan</Badge>
+                                                    ) : (
+                                                        <Badge variant="secondary">Tidak ada</Badge>
+                                                    )}
+                                                </td>
+                                                <td className="py-3 px-4">
+                                                    <div className="flex flex-col space-y-1">
+                                                        {audit.reportFile && (
+                                                            <Button variant="ghost" size="sm" className="justify-start p-0 h-auto">
+                                                                <Download className="mr-1 h-3 w-3" />
+                                                                <span className="text-xs">{audit.reportFile}</span>
+                                                            </Button>
+                                                        )}
+                                                        {audit.evidenceFiles?.map((file, index) => (
+                                                            <Button key={index} variant="ghost" size="sm" className="justify-start p-0 h-auto">
+                                                                <Download className="mr-1 h-3 w-3" />
+                                                                <span className="text-xs">{file}</span>
+                                                            </Button>
+                                                        ))}
+                                                    </div>
+                                                </td>
+                                                <td className="py-3 px-4">
+                                                    <Link href={`/audit/${audit._id}/report`}>
+                                                        <Button variant="outline" size="sm">
+                                                            <FileText className="mr-2 h-4 w-4" />
+                                                            Lihat Laporan
+                                                        </Button>
+                                                    </Link>
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </CardContent>
+                    </Card>
+                </TabsContent>
 
                 {/* --- KONTEN TAB FINDING RESULT DIKEMBALIKAN --- */}
                 <TabsContent value="findings">

--- a/app/api/audits/[id]/route.ts
+++ b/app/api/audits/[id]/route.ts
@@ -7,14 +7,13 @@ const AUDITS_COLLECTION = 'audits';
 // GET: Mengambil satu audit berdasarkan ID
 export async function GET(request: Request, { params }: { params: { id: string } }) {
     try {
+        const { id } = params;
         const { db } = await connectToDatabase();
 
-        // --- PERBAIKAN DI SINI ---
-        const { id } = params;
+
         if (!id || !ObjectId.isValid(id)) {
             return NextResponse.json({ message: 'ID Audit tidak valid atau tidak ada' }, { status: 400 });
         }
-        // -------------------------
 
         const audit = await db.collection(AUDITS_COLLECTION).findOne({ _id: new ObjectId(id) });
         if (!audit) {
@@ -29,13 +28,13 @@ export async function GET(request: Request, { params }: { params: { id: string }
 // PUT: Memperbarui satu audit berdasarkan ID
 export async function PUT(request: Request, { params }: { params: { id: string } }) {
     try {
-        const { db } = await connectToDatabase();
-        // --- PERBAIKAN DI SINI ---
+
         const { id } = params;
+        const { db } = await connectToDatabase();
         if (!id || !ObjectId.isValid(id)) {
             return NextResponse.json({ message: 'ID Audit tidak valid atau tidak ada' }, { status: 400 });
         }
-        // -------------------------
+
 
         const data = await request.json();
         delete data._id;

--- a/app/api/audits/route.ts
+++ b/app/api/audits/route.ts
@@ -1,67 +1,49 @@
-import { NextResponse } from 'next/server';
-import { connectToDatabase } from '@/lib/mongodb';
-import { ObjectId } from 'mongodb';
+import { NextResponse, NextRequest } from 'next/server'
+import { connectToDatabase } from '@/lib/mongodb'
+import { ObjectId } from 'mongodb'
 
-const FINDINGS_COLLECTION = 'findings';
-const AUDITS_COLLECTION = 'audits';
+export const dynamic = 'force-dynamic'
 
-// GET: Mengambil satu finding berdasarkan ID
-export async function GET() {
-    try {
-        const { db } = await connectToDatabase();
-        const audits = await db.collection(AUDITS_COLLECTION).find({}).sort({ date: -1 }).toArray();
-        if (!audits) {
-            console.warn(`Peringatan: Tidak ada data ditemukan di koleksi '${AUDITS_COLLECTION}'.`);
-            return NextResponse.json([]); // Kembalikan array kosong jika tidak ada data
-        }
-        return NextResponse.json(audits, { status: 200 });
-    } catch (error) {
-        console.error("API GET /api/audits FAILED:", error);
-        return NextResponse.json({ message: 'Gagal mengambil data audit.', error: (error as Error).message }, { status: 500 });
-    }
+const AUDITS_COLLECTION = 'audits'
+
+// Ambil seluruh daftar audit
+export async function GET(_req: NextRequest) {
+  try {
+    const { db } = await connectToDatabase()
+    const audits = await db.collection(AUDITS_COLLECTION).find({}).sort({ date: -1 }).toArray()
+    return NextResponse.json(audits, { status: 200 })
+  } catch (error) {
+    return NextResponse.json(
+      { message: 'Gagal mengambil data audit', error: (error as Error).message },
+      { status: 500 }
+    )
+  }
 }
 
+// Buat audit baru
+export async function POST(request: NextRequest) {
+  try {
+    const data = await request.json()
+    const { db } = await connectToDatabase()
 
-// PUT: Memperbarui satu finding berdasarkan ID
-export async function PUT(request: Request, { params }: { params: { id: string } }) {
-    try {
-        const { db } = await connectToDatabase();
-        if (!ObjectId.isValid(params.id)) {
-            return NextResponse.json({ message: 'ID Finding tidak valid' }, { status: 400 });
-        }
-        const data = await request.json();
-        const findingId = new ObjectId(params.id);
-
-        // Update finding yang diubah
-        const updateResult = await db.collection(FINDINGS_COLLECTION).findOneAndUpdate(
-            { _id: findingId },
-            { $set: { ...data, updatedAt: new Date() } },
-            { returnDocument: 'after' }
-        );
-
-        if (!updateResult) {
-            return NextResponse.json({ message: 'Finding tidak ditemukan untuk diperbarui' }, { status: 404 });
-        }
-
-        const updatedFinding = updateResult;
-
-        // Logika Otomatisasi Penyelesaian Audit
-        if (updatedFinding.status === 'Closed' && updatedFinding.auditId) {
-            const openFindingsCount = await db.collection(FINDINGS_COLLECTION).countDocuments({
-                auditId: updatedFinding.auditId,
-                status: { $in: ['Open', 'In Progress'] }
-            });
-
-            if (openFindingsCount === 0) {
-                await db.collection(AUDITS_COLLECTION).updateOne(
-                    { _id: new ObjectId(updatedFinding.auditId) },
-                    { $set: { status: 'Completed', completedDate: new Date().toISOString() } }
-                );
-            }
-        }
-
-        return NextResponse.json(updatedFinding, { status: 200 });
-    } catch (error) {
-        return NextResponse.json({ message: 'Gagal memperbarui finding', error: (error as Error).message }, { status: 500 });
+    if (!data.name || !data.standard || !data.department || !data.date || !data.auditor) {
+      return NextResponse.json({ message: 'Data audit tidak lengkap' }, { status: 400 })
     }
+
+    const newAudit = {
+      ...data,
+      status: data.status || 'Scheduled',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      _id: new ObjectId(),
+    }
+
+    await db.collection(AUDITS_COLLECTION).insertOne(newAudit)
+    return NextResponse.json(newAudit, { status: 201 })
+  } catch (error) {
+    return NextResponse.json(
+      { message: 'Gagal membuat audit', error: (error as Error).message },
+      { status: 500 }
+    )
+  }
 }

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -9,8 +9,9 @@ const COLLECTION_NAME = 'documents';
 // === FUNGSI PUT YANG DIPERBAIKI (TANPA FORMIDABLE) ===
 export async function PUT(request: Request, { params }: { params: { id: string } }) {
   try {
+    const { id } = params;
     const { db } = await connectToDatabase();
-    const id = params.id;
+
 
     if (!id || !ObjectId.isValid(id)) {
       return NextResponse.json({ message: 'Invalid document id' }, { status: 400 });
@@ -85,8 +86,8 @@ export async function PUT(request: Request, { params }: { params: { id: string }
 // Fungsi DELETE (biarkan seperti yang sudah ada, atau gunakan versi ini untuk konsistensi)
 export async function DELETE(request: Request, { params }: { params: { id: string } }) {
   try {
+    const { id } = params;
     const { db } = await connectToDatabase();
-    const id = params.id;
     if (!id || !ObjectId.isValid(id)) {
       return NextResponse.json({ message: 'Invalid document id' }, { status: 400 });
     }

--- a/app/api/files/[id]/route.ts
+++ b/app/api/files/[id]/route.ts
@@ -5,9 +5,10 @@ import { GridFSBucket, ObjectId } from 'mongodb';
 
 export async function GET(request: Request, { params }: { params: { id: string } }) {
     try {
+        const { id: fileIdString } = params;
         const { db } = await connectToDatabase(); //
         const bucket = new GridFSBucket(db, { bucketName: 'uploads' });
-        const fileIdString = params.id;
+
 
         if (!fileIdString || !ObjectId.isValid(fileIdString)) {
             return NextResponse.json({ message: 'Invalid file ID' }, { status: 400 });

--- a/app/api/findings/[id]/route.ts
+++ b/app/api/findings/[id]/route.ts
@@ -7,9 +7,8 @@ const AUDITS_COLLECTION = 'audits';
 
 export async function GET(request: Request, { params }: { params: { id: string } }) {
     try {
-        const { db } = await connectToDatabase();
-
         const { id } = params;
+        const { db } = await connectToDatabase();
         if (!id || !ObjectId.isValid(id)) {
             return NextResponse.json({ message: 'ID Finding tidak valid atau tidak ada' }, { status: 400 });
         }
@@ -26,8 +25,9 @@ export async function GET(request: Request, { params }: { params: { id: string }
 
 export async function PUT(request: Request, { params }: { params: { id: string } }) {
     try {
-        const { db } = await connectToDatabase();
+
         const { id } = params;
+        const { db } = await connectToDatabase();
         if (!id || !ObjectId.isValid(id)) {
             return NextResponse.json({ message: 'ID Finding tidak valid' }, { status: 400 });
         }


### PR DESCRIPTION
## Summary
- implement POST handler for `/api/audits` so new schedules can be saved
- move finish audit button inside the findings tab
- add dedicated finish audit page for uploading the final report
- fix audits API route types
- expand finish audit page with all detail fields and file uploads
- expand audit table headers
- add completed audits listing with files and report links
- create detailed audit report page

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687779087b488321a9236f7ef4ca1436